### PR TITLE
docs: Clarify jq auto-installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ curl -fsSL https://kevinmaes.github.io/claudebar/uninstall.sh | bash
 
 ## Requirements
 
-- `jq` - JSON processor
+- `jq` - JSON processor (installer will offer to install if missing)
+
+<details>
+<summary>Manual installation</summary>
 
 ```bash
 # macOS
@@ -46,6 +49,7 @@ sudo apt install jq
 # Fedora
 sudo dnf install jq
 ```
+</details>
 
 ## What it displays
 


### PR DESCRIPTION
## Summary
- Update Requirements section to clarify that the installer will offer to install jq if missing
- Move manual installation commands to a collapsible details section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm collapsible section works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)