### PR TITLE
feat: show worktree name separately from branch name

### DIFF
--- a/.changeset/worktree-branch-separation.md
+++ b/.changeset/worktree-branch-separation.md
@@ -1,0 +1,13 @@
+---
+"claudebar": minor
+---
+
+feat: show worktree name separately from branch name
+
+When in a git worktree, the statusline now displays the worktree directory name separately from the tracked branch name:
+- Before: 🌳 🌿 feature-branch
+- After: 🌳 worktree-dir | 🌿 feature-branch
+
+This provides clearer semantic meaning:
+- Worktree = WHERE you are (the directory/workspace)
+- Branch = WHAT branch that worktree is tracking

--- a/statusline.sh
+++ b/statusline.sh
@@ -158,19 +158,26 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     # Check if we're in a worktree (git-dir and git-common-dir differ)
     git_dir=$(git rev-parse --git-dir 2>/dev/null)
     git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
-    is_worktree=""
-    if [ "$git_dir" != "$git_common_dir" ]; then
-        is_worktree="${ICON_WORKTREE} "
-    fi
 
     # Get current branch
     branch=$(git -c core.useBuiltinFSMonitor=false rev-parse --abbrev-ref HEAD 2>/dev/null)
 
     if [ -n "$branch" ]; then
+        # If in a worktree, show worktree name separately
+        if [ "$git_dir" != "$git_common_dir" ]; then
+            worktree_name=$(basename "$cwd")
+            if [ -n "$ICON_WORKTREE" ]; then
+                status="$status | ${ICON_WORKTREE} ${GREEN}${worktree_name}${RESET}"
+            else
+                status="$status | ${GREEN}${worktree_name}${RESET}"
+            fi
+        fi
+
+        # Show branch
         if [ -n "$ICON_BRANCH" ]; then
-            status="$status | ${is_worktree}${ICON_BRANCH} ${GREEN}${branch}${RESET}"
+            status="$status | ${ICON_BRANCH} ${GREEN}${branch}${RESET}"
         else
-            status="$status | ${is_worktree}${GREEN}${branch}${RESET}"
+            status="$status | ${GREEN}${branch}${RESET}"
         fi
 
         # Get git status counts (skip optional locks for performance)


### PR DESCRIPTION
## Summary

Fixes #36

When in a git worktree, the statusline now displays the worktree directory name separately from the tracked branch name, providing clearer semantic distinction:

- **Before**: 🌳 🌿 feature-branch
- **After**: 🌳 worktree-dir | 🌿 feature-branch

### Changes made

- Modified statusline.sh:158-181 to extract worktree name using `basename "$cwd"`
- Display worktree name with tree icon (🌳) before branch
- Display branch name with branch icon (🌿) after worktree
- Maintains support for all display modes (icon, label, none)

### Semantic clarity

- **Worktree** = WHERE you are (the directory/workspace)
- **Branch** = WHAT branch that worktree is tracking

## Test plan

- [x] Tested in actual worktree environment (directory: `36`, branch: `36-feat-show-worktree-name-separately-from-branch-name`)
- [x] Verified output shows worktree name and branch name separately
- [x] Confirmed display format: `🌳 36 | 🌿 36-feat-show-worktree-name-separately-from-branch-name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)