### PR TITLE
fix: sync install-dev.sh with shell command option

### DIFF
--- a/.changeset/sync-install-dev-shell-command.md
+++ b/.changeset/sync-install-dev-shell-command.md
@@ -1,0 +1,5 @@
+---
+"claudebar": patch
+---
+
+Sync install-dev.sh with install.sh to include optional shell command installation

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -99,6 +99,44 @@ sed -i.bak "s/MODE=\"\${CLAUDEBAR_MODE:-icon}\"/MODE=\"$MODE\"/" "$STATUSLINE_SC
 rm -f "$STATUSLINE_SCRIPT.bak"
 echo "Display mode set to: $MODE"
 
+# Ask about shell command installation
+echo ""
+echo "Add 'claudebar' command to your shell?"
+echo ""
+echo "This lets you run these commands from anywhere:"
+echo "  claudebar --version       Show installed version"
+echo "  claudebar --help          Show usage and available options"
+echo "  claudebar --update        Update to latest version"
+echo "  claudebar --check-update  Check if update is available"
+echo ""
+read -p "Install to shell? [y/N] " -n 1 -r < /dev/tty
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # Detect shell config file
+    if [ -n "${ZSH_VERSION:-}" ] || [ -f "$HOME/.zshrc" ]; then
+        SHELL_RC="$HOME/.zshrc"
+    else
+        SHELL_RC="$HOME/.bashrc"
+    fi
+
+    # Remove old claudebar function if exists
+    if [ -f "$SHELL_RC" ]; then
+        sed -i.bak '/^# claudebar command$/d; /^claudebar() {/d' "$SHELL_RC" 2>/dev/null || true
+        rm -f "$SHELL_RC.bak"
+    fi
+
+    # Add claudebar function
+    {
+        echo ""
+        echo "# claudebar command"
+        echo 'claudebar() { ~/.claude/statusline.sh "$@"; }'
+    } >> "$SHELL_RC"
+
+    echo "Added claudebar command to $SHELL_RC"
+    echo "Run: source $SHELL_RC  (or restart your terminal)"
+fi
+
 # Set executable permissions
 chmod +x "$STATUSLINE_SCRIPT"
 echo "Set executable permissions on statusline.sh"


### PR DESCRIPTION
## Summary

- Adds the optional `claudebar` shell command installation prompt to `install-dev.sh`
- Syncs functionality that was added to `install.sh` but missed in `install-dev.sh`

## Test plan

- [ ] Run `./install-dev.sh` locally and verify the shell command prompt appears after display mode selection
- [ ] Accept the prompt and verify the function is added to shell config
- [ ] Decline the prompt and verify installation completes without adding the function

🤖 Generated with [Claude Code](https://claude.com/claude-code)