### PR TITLE
feat: add 5-hour billing block progress indicator

### DIFF
--- a/.changeset/billing-block-indicator.md
+++ b/.changeset/billing-block-indicator.md
@@ -1,0 +1,5 @@
+---
+"claudebar": minor
+---
+
+Add 5-hour billing block progress indicator showing session duration as percentage of Claude's billing period

--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -45,6 +45,31 @@ mock_input() {
 EOF
 }
 
+# Generate mock JSON input with billing/cost data
+mock_input_with_billing() {
+    local cwd="$1"
+    local duration_ms="${2:-0}"
+    local context_size="${3:-200000}"
+    local input_tokens="${4:-40000}"
+    local output_tokens="${5:-44000}"
+
+    cat <<EOF
+{
+    "workspace": {
+        "current_dir": "$cwd"
+    },
+    "context_window": {
+        "context_window_size": $context_size,
+        "total_input_tokens": $input_tokens,
+        "total_output_tokens": $output_tokens
+    },
+    "cost": {
+        "total_duration_ms": $duration_ms
+    }
+}
+EOF
+}
+
 # Generate minimal JSON input (no context window)
 mock_input_minimal() {
     local cwd="$1"


### PR DESCRIPTION
## Summary

- Display session duration as percentage of Claude's 5-hour billing period
- Color-coded thresholds: green (< 4h), yellow (4-4.5h), red (> 4.5h)
- Progress bar format: `⏱️ 65% ▮▮▮▯▯ (3h 15m / 5h)`
- Supports all display modes (icon/label/none)
- Gracefully hidden when billing data not present

## Test plan

- [x] All 46 statusline tests pass
- [x] All 16 install tests pass
- [x] Manual verification with mock billing data

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)