### PR TITLE
feat: add cache token breakdown to context display

### DIFF
--- a/.changeset/cache-token-breakdown.md
+++ b/.changeset/cache-token-breakdown.md
@@ -1,0 +1,5 @@
+---
+"claudebar": minor
+---
+
+Add cache token breakdown to context display showing cache creation vs read tokens (C: 40k | R: 44k / 200k)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A bash statusline for Claude Code.
 
 ```
 📂 parent/current | 🌿 main | 📄 S: 0 | U: 2 | A: 1
-claudebar v0.3.0 | 🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (84k/200k)
+🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k)
 ```
 
 ## Why claudebar?
@@ -58,7 +58,7 @@ Or use the built-in update command:
 The statusline shows a yellow `↑` indicator when a newer version is available:
 
 ```
-🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (84k/200k) | ↑ claudebar v0.6.0
+🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ claudebar v0.6.0
 ```
 
 Version checks are cached for 24 hours. To manually check:
@@ -151,7 +151,7 @@ sudo dnf install jq
   <tr>
     <td>🧠</td>
     <td></td>
-    <td>Context window usage (color-coded: green &lt;50%, yellow 50-80%, red &gt;80%)</td>
+    <td>Context window usage with cache breakdown (C: creation, R: read tokens)</td>
   </tr>
   <tr>
     <td>↑</td>
@@ -208,7 +208,7 @@ Add the export to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to persist 
 The statusline shows when a newer version of Claude Code is available in the VS Code marketplace:
 
 ```text
-🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (84k/200k) | ↑ CC v2.1.0
+🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ CC v2.1.0
 ```
 
 This checks the VS Code/Cursor extensions directory to detect your installed version and compares it against the latest marketplace version. Checks are cached for 24 hours.

--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -70,6 +70,33 @@ mock_input_with_billing() {
 EOF
 }
 
+# Generate mock JSON input with cache token data
+mock_input_with_cache() {
+    local cwd="$1"
+    local cache_creation="${2:-40000}"
+    local cache_read="${3:-44000}"
+    local context_size="${4:-200000}"
+    local input_tokens="${5:-40000}"
+    local output_tokens="${6:-44000}"
+
+    cat <<EOF
+{
+    "workspace": {
+        "current_dir": "$cwd"
+    },
+    "context_window": {
+        "context_window_size": $context_size,
+        "total_input_tokens": $input_tokens,
+        "total_output_tokens": $output_tokens,
+        "current_usage": {
+            "cache_creation_input_tokens": $cache_creation,
+            "cache_read_input_tokens": $cache_read
+        }
+    }
+}
+EOF
+}
+
 # Generate minimal JSON input (no context window)
 mock_input_minimal() {
     local cwd="$1"


### PR DESCRIPTION
## Summary
- Display cache token creation vs read counts for better cost optimization awareness
- Format: `🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k)` when cache data available
- Falls back to simple format `(84k/200k)` when cache fields are missing
- Works across all 3 display modes (icon, label, none)

Closes #39

## Test plan
- [x] Run `bats tests/` - all 69 tests pass
- [x] Test with cache data present - shows `C:` and `R:` breakdown
- [x] Test without cache data - falls back to simple format
- [x] Test all display modes (icon/label/none)
- [x] Test edge cases: zero creation tokens, zero read tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)