### PR TITLE
fix: trigger CI on Version Packages PRs via workflow_run

### DIFF
--- a/.changeset/ci-workflow-run-trigger.md
+++ b/.changeset/ci-workflow-run-trigger.md
@@ -1,0 +1,7 @@
+---
+"claudebar": patch
+---
+
+Fix CI not running on Version Packages PRs from changeset-release branches
+
+When the changesets bot creates or updates a Version Packages PR using GITHUB_TOKEN, GitHub's security feature prevents workflows from triggering. This fix adds a `workflow_run` trigger to the CI workflow that runs tests after the Release workflow completes, and reports status back to the PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,63 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, "changeset-release/*"]
+    branches: [main, dev]
   pull_request:
-    branches: [main, dev, "changeset-release/*"]
+    branches: [main, dev]
+  # Trigger CI when Release workflow completes (for changeset PRs)
+  # This is needed because GITHUB_TOKEN pushes don't trigger workflows
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [dev]
 
 jobs:
+  # Check if changeset-release branch exists and has a PR (for workflow_run trigger)
+  check-changeset-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' }}
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      pr_head_sha: ${{ steps.check.outputs.pr_head_sha }}
+    steps:
+      - name: Check for changeset PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if Release workflow succeeded
+          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if changeset-release/dev branch exists and has a PR
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls \
+            --jq '.[] | select(.head.ref == "changeset-release/dev" and .state == "open") | {sha: .head.sha}' \
+            2>/dev/null || echo "")
+
+          if [ -n "$PR_DATA" ]; then
+            SHA=$(echo "$PR_DATA" | jq -r '.sha')
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "pr_head_sha=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
   test:
     runs-on: ubuntu-latest
+    needs: [check-changeset-pr]
+    # Run for push/pull_request, or for workflow_run when there's a changeset PR
+    if: |
+      always() &&
+      (github.event_name != 'workflow_run' || needs.check-changeset-pr.outputs.should_run == 'true')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For workflow_run, checkout the changeset-release branch
+          ref: ${{ github.event_name == 'workflow_run' && 'changeset-release/dev' || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -28,12 +74,36 @@ jobs:
       - name: Run interactive tests
         run: make test-interactive
 
+      # Report status to changeset PR when triggered via workflow_run
+      - name: Report status to PR
+        if: ${{ always() && github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS="${{ job.status }}"
+          SHA="${{ needs.check-changeset-pr.outputs.pr_head_sha }}"
+          if [ -n "$SHA" ]; then
+            gh api repos/${{ github.repository }}/statuses/$SHA \
+              -f state="$STATUS" \
+              -f context="CI / test (ubuntu)" \
+              -f description="Ubuntu tests $STATUS" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+
   test-macos:
     runs-on: macos-latest
+    needs: [check-changeset-pr]
+    # Run for push/pull_request, or for workflow_run when there's a changeset PR
+    if: |
+      always() &&
+      (github.event_name != 'workflow_run' || needs.check-changeset-pr.outputs.should_run == 'true')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For workflow_run, checkout the changeset-release branch
+          ref: ${{ github.event_name == 'workflow_run' && 'changeset-release/dev' || github.ref }}
 
       - name: Install dependencies
         run: brew install bats-core jq shellcheck expect
@@ -46,3 +116,19 @@ jobs:
 
       - name: Run interactive tests
         run: make test-interactive
+
+      # Report status to changeset PR when triggered via workflow_run
+      - name: Report status to PR
+        if: ${{ always() && github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS="${{ job.status }}"
+          SHA="${{ needs.check-changeset-pr.outputs.pr_head_sha }}"
+          if [ -n "$SHA" ]; then
+            gh api repos/${{ github.repository }}/statuses/$SHA \
+              -f state="$STATUS" \
+              -f context="CI / test (macos)" \
+              -f description="macOS tests $STATUS" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi


### PR DESCRIPTION
## Summary
- Fixes CI not running on "Version Packages" PRs from `changeset-release/*` branches
- Adds `workflow_run` trigger to run CI after the Release workflow completes
- Reports test status back to the PR via GitHub commit status API

## Root Cause
When the changesets bot pushes to `changeset-release/dev` using `GITHUB_TOKEN`, GitHub's security feature prevents workflows from triggering to avoid infinite loops. This left Version Packages PRs with no CI checks.

## Solution
1. Added `workflow_run` trigger on Release workflow completion
2. New `check-changeset-pr` job verifies there's an open changeset PR
3. Test jobs checkout the `changeset-release/dev` branch when triggered via workflow_run
4. Status is reported to the PR's commit SHA so checks appear on the PR

## Test plan
- [ ] Merge this PR to dev
- [ ] Verify Release workflow triggers CI via workflow_run
- [ ] Confirm CI status appears on the Version Packages PR (#69)
- [ ] Verify normal push/pull_request triggers still work

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)