### PR TITLE
fix: add manual CI triggers for Version Packages PRs

### DIFF
--- a/.changeset/ci-manual-triggers.md
+++ b/.changeset/ci-manual-triggers.md
@@ -1,0 +1,9 @@
+---
+"claudebar": patch
+---
+
+Add manual CI triggers for Version Packages PRs
+
+Adds two ways to trigger CI on PRs that don't automatically run checks:
+- Manual trigger from GitHub Actions tab (workflow_dispatch)
+- Comment "/run-ci" on a PR to trigger tests (issue_comment)

--- a/.changeset/ci-workflow-run-trigger.md
+++ b/.changeset/ci-workflow-run-trigger.md
@@ -1,7 +1,0 @@
----
-"claudebar": patch
----
-
-Fix CI not running on Version Packages PRs from changeset-release branches
-
-When the changesets bot creates or updates a Version Packages PR using GITHUB_TOKEN, GitHub's security feature prevents workflows from triggering. This fix adds a `workflow_run` trigger to the CI workflow that runs tests after the Release workflow completes, and reports status back to the PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,60 +5,42 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
-  # Trigger CI when Release workflow completes (for changeset PRs)
-  # This is needed because GITHUB_TOKEN pushes don't trigger workflows
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
-    branches: [dev]
+  # Allow manual trigger from Actions tab
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run tests on'
+        required: false
+        default: ''
+  # Allow trigger via PR comment "/run-ci"
+  issue_comment:
+    types: [created]
 
 jobs:
-  # Check if changeset-release branch exists and has a PR (for workflow_run trigger)
-  check-changeset-pr:
+  test:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' }}
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-      pr_head_sha: ${{ steps.check.outputs.pr_head_sha }}
+    # Run on push/pull_request, workflow_dispatch, or "/run-ci" comment on a PR
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-ci'))
+
     steps:
-      - name: Check for changeset PR
-        id: check
+      - name: Get PR branch for comment trigger
+        if: github.event_name == 'issue_comment'
+        id: get-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if Release workflow succeeded
-          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo "sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
 
-          # Check if changeset-release/dev branch exists and has a PR
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls \
-            --jq '.[] | select(.head.ref == "changeset-release/dev" and .state == "open") | {sha: .head.sha}' \
-            2>/dev/null || echo "")
-
-          if [ -n "$PR_DATA" ]; then
-            SHA=$(echo "$PR_DATA" | jq -r '.sha')
-            echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "pr_head_sha=$SHA" >> $GITHUB_OUTPUT
-          else
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
-
-  test:
-    runs-on: ubuntu-latest
-    needs: [check-changeset-pr]
-    # Run for push/pull_request, or for workflow_run when there's a changeset PR
-    if: |
-      always() &&
-      (github.event_name != 'workflow_run' || needs.check-changeset-pr.outputs.should_run == 'true')
-
-    steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # For workflow_run, checkout the changeset-release branch
-          ref: ${{ github.event_name == 'workflow_run' && 'changeset-release/dev' || github.ref }}
+          ref: ${{ github.event_name == 'issue_comment' && steps.get-branch.outputs.ref || github.event.inputs.branch || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -74,36 +56,30 @@ jobs:
       - name: Run interactive tests
         run: make test-interactive
 
-      # Report status to changeset PR when triggered via workflow_run
-      - name: Report status to PR
-        if: ${{ always() && github.event_name == 'workflow_run' }}
+  test-macos:
+    runs-on: macos-latest
+    # Run on push/pull_request, workflow_dispatch, or "/run-ci" comment on a PR
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-ci'))
+
+    steps:
+      - name: Get PR branch for comment trigger
+        if: github.event_name == 'issue_comment'
+        id: get-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          STATUS="${{ job.status }}"
-          SHA="${{ needs.check-changeset-pr.outputs.pr_head_sha }}"
-          if [ -n "$SHA" ]; then
-            gh api repos/${{ github.repository }}/statuses/$SHA \
-              -f state="$STATUS" \
-              -f context="CI / test (ubuntu)" \
-              -f description="Ubuntu tests $STATUS" \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          fi
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo "sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
 
-  test-macos:
-    runs-on: macos-latest
-    needs: [check-changeset-pr]
-    # Run for push/pull_request, or for workflow_run when there's a changeset PR
-    if: |
-      always() &&
-      (github.event_name != 'workflow_run' || needs.check-changeset-pr.outputs.should_run == 'true')
-
-    steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # For workflow_run, checkout the changeset-release branch
-          ref: ${{ github.event_name == 'workflow_run' && 'changeset-release/dev' || github.ref }}
+          ref: ${{ github.event_name == 'issue_comment' && steps.get-branch.outputs.ref || github.event.inputs.branch || github.ref }}
 
       - name: Install dependencies
         run: brew install bats-core jq shellcheck expect
@@ -116,19 +92,3 @@ jobs:
 
       - name: Run interactive tests
         run: make test-interactive
-
-      # Report status to changeset PR when triggered via workflow_run
-      - name: Report status to PR
-        if: ${{ always() && github.event_name == 'workflow_run' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          STATUS="${{ job.status }}"
-          SHA="${{ needs.check-changeset-pr.outputs.pr_head_sha }}"
-          if [ -n "$SHA" ]; then
-            gh api repos/${{ github.repository }}/statuses/$SHA \
-              -f state="$STATUS" \
-              -f context="CI / test (macos)" \
-              -f description="macOS tests $STATUS" \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          fi


### PR DESCRIPTION
## Summary
- Reverts the complex `workflow_run` approach that didn't work
- Adds two simple ways to trigger CI on PRs that don't auto-run checks:
  1. **Manual trigger from Actions tab** - `workflow_dispatch` with optional branch input
  2. **PR comment trigger** - comment `/run-ci` on any PR to run tests

## How to use

### From Actions tab:
1. Go to Actions → CI workflow
2. Click "Run workflow"
3. Optionally enter a branch name (e.g., `changeset-release/dev`)
4. Click "Run workflow"

### From PR comment:
1. Comment `/run-ci` on the PR
2. CI will automatically run on that PR's branch

## Test plan
- [ ] Merge this PR to dev
- [ ] Test manual trigger from Actions tab on `changeset-release/dev`
- [ ] Test `/run-ci` comment on Version Packages PR

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)