### PR TITLE
fix: auto-trigger CI on Version Packages PRs

### DIFF
--- a/.changeset/fix-empty-branch-input.md
+++ b/.changeset/fix-empty-branch-input.md
@@ -2,4 +2,4 @@
 "claudebar": patch
 ---
 
-Change CI manual trigger input from branch name to PR number
+Auto-trigger CI on Version Packages PRs using PAT for empty commit push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, changeset-release/dev]
   pull_request:
     branches: [main, dev]
   # Allow manual trigger from Actions tab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create Version PR
+        id: changesets
         uses: changesets/action@v1
         with:
           title: 'Version Packages'
@@ -43,3 +44,16 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Push empty commit to trigger CI on the Version Packages PR
+      # Uses PAT (CHANGESETS_TOKEN) because GITHUB_TOKEN pushes don't trigger workflows
+      - name: Trigger CI on Version Packages PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.CHANGESETS_TOKEN }}@github.com/${{ github.repository }}.git
+          git fetch origin changeset-release/dev
+          git checkout changeset-release/dev
+          git commit --allow-empty -m "chore: trigger CI [skip release]"
+          git push origin changeset-release/dev


### PR DESCRIPTION
## Summary
Automatically triggers CI on Version Packages PRs by pushing an empty commit using `CHANGESETS_TOKEN` (PAT).

## How it works
1. Release workflow creates/updates Version Packages PR via changesets action
2. If a PR was created/updated, push an empty commit to `changeset-release/dev` using the PAT
3. PAT pushes trigger workflows (unlike `GITHUB_TOKEN`)
4. CI runs on the push to `changeset-release/dev`

## Changes
- **release.yml**: Added step to push empty commit using `CHANGESETS_TOKEN`
- **ci.yml**: Added `changeset-release/dev` to push trigger branches

## Test plan
- [ ] Merge this PR to dev
- [ ] Verify Release workflow pushes empty commit
- [ ] Verify CI triggers on Version Packages PR

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)