### PR TITLE
fix: clear GITHUB_TOKEN credentials before pushing with PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,13 @@ jobs:
       - name: Trigger CI on Version Packages PR
         if: steps.changesets.outputs.pullRequestNumber != ''
         run: |
+          # Clear GITHUB_TOKEN credentials set by actions/checkout
+          git config --unset-all http.https://github.com/.extraheader || true
+          # Set up PAT authentication
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.CHANGESETS_TOKEN }}@github.com/${{ github.repository }}.git
           git fetch origin changeset-release/dev
           git checkout changeset-release/dev
-          git commit --allow-empty -m "chore: trigger CI [skip release]"
+          git commit --allow-empty -m "chore: trigger CI"
           git push origin changeset-release/dev


### PR DESCRIPTION
## Summary
Fixes CI not triggering on Version Packages PRs by clearing the GITHUB_TOKEN extraheader config before pushing with the PAT.

## Problem
`actions/checkout` sets up credentials via `http.https://github.com/.extraheader` config, which takes precedence over the remote URL. Even though we set `CHANGESETS_TOKEN` in the remote URL, git was still using the cached GITHUB_TOKEN credentials.

## Solution
Clear the extraheader config before setting up the PAT:
```bash
git config --unset-all http.https://github.com/.extraheader || true
```

## Test plan
- [ ] Merge this PR to dev
- [ ] Verify Release workflow pushes empty commit
- [ ] Verify CI triggers on changeset-release/dev push

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)