### PR TITLE
chore: clean up failed CI trigger attempts

### DIFF
--- a/.changeset/ci-auto-trigger.md
+++ b/.changeset/ci-auto-trigger.md
@@ -1,0 +1,5 @@
+---
+"claudebar": patch
+---
+
+Auto-trigger CI on Version Packages PRs by pushing empty commit with PAT

--- a/.changeset/ci-manual-triggers.md
+++ b/.changeset/ci-manual-triggers.md
@@ -1,9 +1,0 @@
----
-"claudebar": patch
----
-
-Add manual CI triggers for Version Packages PRs
-
-Adds two ways to trigger CI on PRs that don't automatically run checks:
-- Manual trigger from GitHub Actions tab (workflow_dispatch)
-- Comment "/run-ci" on a PR to trigger tests (issue_comment)

--- a/.changeset/ci-status-reporting.md
+++ b/.changeset/ci-status-reporting.md
@@ -1,5 +1,0 @@
----
-"claudebar": patch
----
-
-Report CI status to PR when triggered via /run-ci comment

--- a/.changeset/empty-test.md
+++ b/.changeset/empty-test.md
@@ -1,5 +1,0 @@
----
-"claudebar": patch
----
-
-Test empty commit to verify CI trigger on Version Packages PR

--- a/.changeset/fix-empty-branch-input.md
+++ b/.changeset/fix-empty-branch-input.md
@@ -1,5 +1,0 @@
----
-"claudebar": patch
----
-
-Auto-trigger CI on Version Packages PRs using PAT for empty commit push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,43 +5,14 @@ on:
     branches: [main, dev, changeset-release/dev]
   pull_request:
     branches: [main, dev]
-  # Allow manual trigger from Actions tab
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to run tests on (leave empty for current branch)'
-        required: false
-        default: ''
-  # Allow trigger via PR comment "/run-ci"
-  issue_comment:
-    types: [created]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Run on push/pull_request, workflow_dispatch, or "/run-ci" comment on a PR
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-ci'))
 
     steps:
-      - name: Get PR branch
-        if: github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
-        id: get-branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUM="${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.inputs.pr_number }}"
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM)
-          echo "ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-          echo "sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
-
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.get-branch.outputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -57,42 +28,12 @@ jobs:
       - name: Run interactive tests
         run: make test-interactive
 
-      - name: Report status to PR
-        if: ${{ always() && steps.get-branch.outputs.sha != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/${{ steps.get-branch.outputs.sha }} \
-            -f state="${{ job.status }}" \
-            -f context="CI / test (ubuntu)" \
-            -f description="Ubuntu tests ${{ job.status }}" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
   test-macos:
     runs-on: macos-latest
-    # Run on push/pull_request, workflow_dispatch, or "/run-ci" comment on a PR
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-ci'))
 
     steps:
-      - name: Get PR branch
-        if: github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
-        id: get-branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUM="${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.inputs.pr_number }}"
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM)
-          echo "ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-          echo "sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
-
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.get-branch.outputs.ref || github.ref }}
 
       - name: Install dependencies
         run: brew install bats-core jq shellcheck expect
@@ -105,14 +46,3 @@ jobs:
 
       - name: Run interactive tests
         run: make test-interactive
-
-      - name: Report status to PR
-        if: ${{ always() && steps.get-branch.outputs.sha != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/${{ steps.get-branch.outputs.sha }} \
-            -f state="${{ job.status }}" \
-            -f context="CI / test (macos)" \
-            -f description="macOS tests ${{ job.status }}" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
Removes the unused manual trigger code from CI workflow now that the PAT-based empty commit push is working.

## Removed
- `workflow_dispatch` with `pr_number` input
- `issue_comment` `/run-ci` trigger  
- "Get PR branch" steps
- "Report status to PR" steps
- Obsolete changesets from failed attempts

## What remains
The working solution in `release.yml`:
1. After changesets action creates/updates Version Packages PR
2. Clear GITHUB_TOKEN credentials
3. Push empty commit using `CHANGESETS_TOKEN` (PAT)
4. CI triggers on push to `changeset-release/dev`

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)