### PR TITLE
feat: notify user when no missed prompts during update

### DIFF
--- a/.changeset/notify-no-missed-prompts.md
+++ b/.changeset/notify-no-missed-prompts.md
@@ -1,0 +1,8 @@
+---
+"claudebar": patch
+---
+
+Notify user when no missed prompts during update
+
+- When updating and there are no new options to configure, the user is now notified with "All features are already configured. No new options to show."
+- This clarifies why no interactive prompts appeared during the update process

--- a/update-dev.sh
+++ b/update-dev.sh
@@ -281,6 +281,12 @@ else
                         ;;
                 esac
             done
+
+            # Notify user if no new options were found
+            if [ -z "$NEW_OPTIONS" ]; then
+                echo ""
+                echo "All features are already configured. No new options to show."
+            fi
         else
             echo "Warning: Could not download options manifest. Skipping retroactive prompts."
         fi

--- a/update.sh
+++ b/update.sh
@@ -275,6 +275,12 @@ else
                         ;;
                 esac
             done
+
+            # Notify user if no new options were found
+            if [ -z "$NEW_OPTIONS" ]; then
+                echo ""
+                echo "All features are already configured. No new options to show."
+            fi
         else
             echo "Warning: Could not download options manifest. Skipping retroactive prompts."
         fi


### PR DESCRIPTION
## Summary

- When updating and there are no new options to configure, the user is now notified with "All features are already configured. No new options to show."
- This clarifies why no interactive prompts appeared during the update process
- Applied to both `update.sh` and `update-dev.sh`

## Test plan

- [ ] Update from a version where all features are already configured
- [ ] Verify the message "All features are already configured. No new options to show." is displayed
- [ ] Verify update still works correctly when there ARE new options to show

🤖 Generated with [Claude Code](https://claude.com/claude-code)