### PR TITLE
feat: skip shell function prompt when installing via npx

### DIFF
--- a/.changeset/skip-shell-prompt-npx.md
+++ b/.changeset/skip-shell-prompt-npx.md
@@ -1,0 +1,5 @@
+---
+"claudebar": minor
+---
+
+Skip shell function prompt when installing via npx

--- a/bin/claudebar.js
+++ b/bin/claudebar.js
@@ -38,13 +38,13 @@ Documentation: https://github.com/kevinmaes/claudebar
 `);
 };
 
-const runScript = (scriptName) => {
+const runScript = (scriptName, args = []) => {
   const scriptPath = join(rootDir, scriptName);
 
   // Check for bash availability
   const shell = process.platform === 'win32' ? 'bash' : '/bin/bash';
 
-  const child = spawn(shell, [scriptPath], {
+  const child = spawn(shell, [scriptPath, ...args], {
     stdio: 'inherit',
     cwd: rootDir,
   });
@@ -65,7 +65,7 @@ const runScript = (scriptName) => {
 };
 
 const commands = {
-  install: () => runScript('install.sh'),
+  install: () => runScript('install.sh', ['--skip-shell-prompt']),
   uninstall: () => runScript('uninstall.sh'),
   update: () => runScript('update.sh'),
 };


### PR DESCRIPTION
## Summary
- Add `--skip-shell-prompt` flag to `install.sh`
- Pass flag from Node CLI when running install
- curl-based installs continue to offer the shell prompt

Closes #107

## Test plan
- [ ] Run `npx claudebar` and verify shell prompt is skipped
- [ ] Run `curl -fsSL .../install.sh | bash` and verify shell prompt still appears
- [ ] All CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)