### PR TITLE
feat: detect existing installation and prompt to skip or update

### DIFF
--- a/.changeset/detect-existing-installation.md
+++ b/.changeset/detect-existing-installation.md
@@ -1,0 +1,5 @@
+---
+"claudebar": minor
+---
+
+Detect existing installation and prompt user to update, reinstall, or cancel


### PR DESCRIPTION
## Summary
- Detect existing claudebar installation when running `install`
- Show installed version and whether an update is available
- Prompt user with options: Update (preserves config), Reinstall (fresh), or Cancel

## Changes
- `install.sh`: Added detection logic at start of script (lines 29-80)
- `tests/install.bats`: Added 8 tests for version comparison and detection logic

## User Experience
```
$ npx claudebar install

claudebar v0.7.0 is installed. (v0.8.0 available)

What would you like to do?

  1) Update       - Update to latest (preserves config)
  2) Reinstall    - Fresh install (reconfigure all options)
  3) Cancel       - Exit without changes

Enter choice [1-3]:
```

## Test plan
- [x] All 32 install.bats tests pass
- [x] All cli.bats and statusline.bats tests pass
- [ ] Manual test: Run install with existing installation, choose Update
- [ ] Manual test: Run install with existing installation, choose Reinstall
- [ ] Manual test: Run install with existing installation, choose Cancel

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)