### PR TITLE
fix: sync main into dev to resolve merge conflict

### DIFF
--- a/.changeset/revise-readme-docs.md
+++ b/.changeset/revise-readme-docs.md
@@ -1,0 +1,5 @@
+---
+"claudebar": patch
+---
+
+Improve README update section: add claudebar shell command option, combine update notification sections, and update examples to use Opus 4.5

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ curl -fsSL https://raw.githubusercontent.com/kevinmaes/claudebar/main/install.sh
 curl -fsSL https://kevinmaes.github.io/claudebar/update.sh | bash
 ```
 
+If you added Claudebar to your shell during installation:
+
+```bash
+claudebar update
+```
+
 Or use the built-in update command or npx:
 
 ```bash
@@ -63,15 +69,29 @@ Or use the built-in update command or npx:
 npx claudebar update
 ```
 
-### Update Notification
+### Update Notifications
 
-The statusline shows a yellow `↑` indicator when a newer version is available:
+The statusline shows yellow `↑` indicators when newer versions are available. Version checks are cached for 24 hours.
+
+**Claudebar update:**
 
 ```
-🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ claudebar v0.6.0
+🤖 Opus 4.5 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ claudebar v0.6.0
 ```
 
-Version checks are cached for 24 hours. To manually check:
+**Claude Code update:**
+
+```
+🤖 Opus 4.5 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ CC v2.1.0
+```
+
+The Claude Code indicator checks the VS Code/Cursor extensions directory to detect your installed version and compares it against the latest marketplace version. To disable:
+
+```bash
+export CLAUDEBAR_SHOW_CLAUDE_UPDATE=false
+```
+
+To manually check for updates:
 
 ```bash
 ~/.claude/statusline.sh --check-update
@@ -217,22 +237,6 @@ export CLAUDEBAR_DISPLAY_PATH=both     # Shows project (parent/current)
 Using `project` mode is recommended when working with multiple projects, as `parent/current` can be confusing.
 
 Add the export to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to persist the setting.
-
-### Claude Code Update Indicator
-
-The statusline shows when a newer version of Claude Code is available in the VS Code marketplace:
-
-```text
-🤖 Sonnet 4 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ CC v2.1.0
-```
-
-This checks the VS Code/Cursor extensions directory to detect your installed version and compares it against the latest marketplace version. Checks are cached for 24 hours.
-
-To disable this indicator:
-
-```bash
-export CLAUDEBAR_SHOW_CLAUDE_UPDATE=false
-```
 
 ## CLI Flags
 


### PR DESCRIPTION
## Summary
- Merges main back into dev to resolve README.md conflict
- The deploy workflow was failing because main and dev had diverged (PR #96 was merged directly to main)
- Combines both versions of the Update section documentation

## Test plan
- [ ] CI passes
- [ ] After merge, re-run the deploy workflow to promote dev to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)