### PR TITLE
fix: cap context progress bar at 5 segments when over 100%

### DIFF
--- a/.changeset/fix-context-bar-overflow.md
+++ b/.changeset/fix-context-bar-overflow.md
@@ -1,0 +1,5 @@
+---
+"claudebar": patch
+---
+
+Fix context progress bar overflow when usage exceeds 100%

--- a/statusline.sh
+++ b/statusline.sh
@@ -381,9 +381,11 @@ if [ -n "$context_size" ] && [ "$context_size" -gt 0 ] 2>/dev/null; then
     cache_creation_k=$((cache_creation / 1000))
     cache_read_k=$((cache_read / 1000))
 
-    # Build progress bar (5 segments)
+    # Build progress bar (5 segments, capped at 100%)
     bar_width=5
-    filled=$((percent * bar_width / 100))
+    bar_percent=$percent
+    [ "$bar_percent" -gt 100 ] && bar_percent=100
+    filled=$((bar_percent * bar_width / 100))
     empty=$((bar_width - filled))
     bar="${CTX_COLOR}"
     for ((i=0; i<filled; i++)); do bar+="▮"; done

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -323,6 +323,20 @@ teardown() {
     [[ "$result" == *$'\033[31m'* ]]
 }
 
+@test "context window bar capped at 5 segments when over 100%" {
+    TEST_REPO=$(setup_git_repo)
+
+    # 600k tokens out of 200k = 300% (way over capacity)
+    result=$(mock_input "$TEST_REPO" 200000 300000 300000 | "$STATUSLINE" | strip_colors)
+
+    # Should show percentage over 100%
+    [[ "$result" == *"300%"* ]]
+    # Bar should still be exactly 5 filled segments (▮▮▮▮▮), not more
+    [[ "$result" == *"▮▮▮▮▮"* ]]
+    # Should NOT have 6+ segments
+    [[ "$result" != *"▮▮▮▮▮▮"* ]]
+}
+
 # =============================================================================
 # Billing Block Tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixed progress bar overflow when context usage exceeds 100%
- Bar now caps at 5 filled segments while still showing actual percentage (e.g., "299% ▮▮▮▮▮")
- Added test to prevent regression

## Test plan
- [x] Run `bats tests/` - all 112 tests pass
- [x] Verify new test covers the overflow scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)