### PR TITLE
fix: remove misleading context percentage and progress bar display

### DIFF
--- a/.changeset/remove-context-percentage.md
+++ b/.changeset/remove-context-percentage.md
@@ -1,0 +1,16 @@
+---
+"claudebar": minor
+---
+
+Remove misleading context window percentage and progress bar display
+
+Claude Code's statusline API only provides cumulative session tokens, not current context window usage. This caused the percentage to show impossible values (e.g., 299%) after context auto-compaction.
+
+Changes:
+- Removed percentage display and progress bar from context section
+- Changed icon from 🧠 to 💾 to reflect "Cache" instead of "Context"
+- Now displays only cache tokens when available: `💾 C: 40k | R: 44k`
+- Added note in README explaining the limitation
+
+The feature will be restored when Claude Code provides accurate context data.
+See: https://github.com/anthropics/claude-code/issues/13783

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A bash statusline for Claude Code.
 
 **Git-First Design** - See your branch, staged files, unstaged changes, and untracked files at a glance. Includes worktree support for advanced workflows.
 
-**Visual Context Tracking** - Color-coded progress bars (▮▮▯▯▯) make it easy to monitor your context window usage. Green under 50%, yellow 50-80%, red above 80%.
+**Cache Token Display** - See your cache token usage at a glance (C: creation, R: read tokens). Helps you understand how your context is being utilized.
 
 **Simple Configuration** - Three display modes via a single environment variable. No complex config files to maintain.
 
@@ -76,13 +76,13 @@ The statusline shows yellow `↑` indicators when newer versions are available. 
 **Claudebar update:**
 
 ```
-🤖 Opus 4.5 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ claudebar v0.6.0
+🤖 Opus 4.5 | 💾 C: 40k | R: 44k | ↑ claudebar v0.6.0
 ```
 
 **Claude Code update:**
 
 ```
-🤖 Opus 4.5 | 🧠 42% ▮▮▯▯▯ (C: 40k | R: 44k / 200k) | ↑ CC v2.1.0
+🤖 Opus 4.5 | 💾 C: 40k | R: 44k | ↑ CC v2.1.0
 ```
 
 The Claude Code indicator checks the VS Code/Cursor extensions directory to detect your installed version and compares it against the latest marketplace version. To disable:
@@ -184,9 +184,9 @@ sudo dnf install jq
     <td>Untracked/added file count</td>
   </tr>
   <tr>
-    <td>🧠</td>
-    <td>Context</td>
-    <td>Context window usage with cache breakdown (C: creation, R: read tokens)</td>
+    <td>💾</td>
+    <td>Cache</td>
+    <td>Cache token usage (C: creation, R: read tokens)</td>
   </tr>
   <tr>
     <td>↑</td>
@@ -199,6 +199,8 @@ sudo dnf install jq
     <td>Update available (yellow, shown when newer version exists in VS Code marketplace)</td>
   </tr>
 </table>
+
+> **Note:** Context window percentage display was removed because Claude Code's statusline API only provides cumulative session tokens, not current context usage. See [anthropics/claude-code#13783](https://github.com/anthropics/claude-code/issues/13783) for details. Cache tokens are still displayed when available.
 
 ## Configuration
 

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -242,7 +242,6 @@ teardown() {
     [[ "$result" == *"📂"* ]]
     [[ "$result" == *"🌿"* ]]
     [[ "$result" == *"📄"* ]]
-    [[ "$result" == *"🧠"* ]]
 }
 
 @test "label mode shows text labels" {
@@ -258,7 +257,6 @@ teardown() {
     [[ "$result" == *"DIR:"* ]]
     [[ "$result" == *"BRANCH:"* ]]
     [[ "$result" == *"STAGED:"* ]]
-    [[ "$result" == *"Context:"* ]]
 }
 
 @test "none mode shows minimal output" {
@@ -280,47 +278,30 @@ teardown() {
 }
 
 # =============================================================================
-# Context Window Tests
+# Cache Token Display Tests
+# Note: Context percentage/progress bar removed due to Claude Code API limitations
+# See: https://github.com/anthropics/claude-code/issues/13783
 # =============================================================================
 
-@test "displays context window usage" {
+@test "displays cache tokens when available" {
     TEST_REPO=$(setup_git_repo)
 
-    # 84k tokens out of 200k = 42%
+    # C: 40k, R: 44k
+    result=$(mock_input_with_cache "$TEST_REPO" 40000 44000 | "$STATUSLINE" | strip_colors)
+
+    [[ "$result" == *"C: 40k"* ]]
+    [[ "$result" == *"R: 44k"* ]]
+}
+
+@test "hides cache display when no cache data" {
+    TEST_REPO=$(setup_git_repo)
+
+    # Standard input without cache data (cache_creation=0, cache_read=0)
     result=$(mock_input "$TEST_REPO" 200000 40000 44000 | "$STATUSLINE" | strip_colors)
 
-    [[ "$result" == *"42%"* ]]
-    [[ "$result" == *"84k/200k"* ]]
-}
-
-@test "context window green when under 50%" {
-    TEST_REPO=$(setup_git_repo)
-
-    # 20k tokens out of 200k = 10%
-    result=$(mock_input "$TEST_REPO" 200000 10000 10000 | "$STATUSLINE")
-
-    # Should contain green color code
-    [[ "$result" == *$'\033[32m'* ]]
-}
-
-@test "context window yellow when 50-79%" {
-    TEST_REPO=$(setup_git_repo)
-
-    # 120k tokens out of 200k = 60%
-    result=$(mock_input "$TEST_REPO" 200000 60000 60000 | "$STATUSLINE")
-
-    # Should contain yellow color code
-    [[ "$result" == *$'\033[33m'* ]]
-}
-
-@test "context window red when 80%+" {
-    TEST_REPO=$(setup_git_repo)
-
-    # 180k tokens out of 200k = 90%
-    result=$(mock_input "$TEST_REPO" 200000 90000 90000 | "$STATUSLINE")
-
-    # Should contain red color code
-    [[ "$result" == *$'\033[31m'* ]]
+    # Should NOT show cache indicator
+    [[ "$result" != *"C:"* ]]
+    [[ "$result" != *"R:"* ]]
 }
 
 # =============================================================================
@@ -419,14 +400,14 @@ teardown() {
     [[ "$result" != *"/ 5h"* ]]
 }
 
-@test "billing block displays alongside context window" {
+@test "billing block displays alongside cache tokens" {
     TEST_REPO=$(setup_git_repo)
 
-    # 2 hours billing, 42% context
-    result=$(mock_input_with_billing "$TEST_REPO" 7200000 200000 40000 44000 | "$STATUSLINE" | strip_colors)
+    # 2 hours billing with cache data
+    result=$(mock_input_with_billing "$TEST_REPO" 7200000 200000 40000 44000 40000 44000 | "$STATUSLINE" | strip_colors)
 
     # Should have both indicators
-    [[ "$result" == *"84k/200k"* ]]
+    [[ "$result" == *"C: 40k"* ]]
     [[ "$result" == *"/ 5h"* ]]
 }
 
@@ -446,92 +427,70 @@ teardown() {
     [[ "$result" != *"S:"* ]]
 }
 
-@test "handles missing context window data" {
+@test "handles missing cache data gracefully" {
     TEST_REPO=$(setup_git_repo)
 
     result=$(mock_input_minimal "$TEST_REPO" | "$STATUSLINE" | strip_colors)
 
-    # Should not contain context percentage
-    [[ "$result" != *"%"* ]]
-}
-
-# =============================================================================
-# Cache Token Breakdown Tests
-# =============================================================================
-
-@test "displays cache token breakdown when cache data available" {
-    TEST_REPO=$(setup_git_repo)
-
-    # C: 40k, R: 44k, context_size: 200k
-    result=$(mock_input_with_cache "$TEST_REPO" 40000 44000 200000 40000 44000 | "$STATUSLINE" | strip_colors)
-
-    [[ "$result" == *"C: 40k"* ]]
-    [[ "$result" == *"R: 44k"* ]]
-    [[ "$result" == *"/ 200k"* ]]
-}
-
-@test "falls back to simple format when no cache data" {
-    TEST_REPO=$(setup_git_repo)
-
-    # Standard input without cache data
-    result=$(mock_input "$TEST_REPO" 200000 40000 44000 | "$STATUSLINE" | strip_colors)
-
-    # Should show simple format (84k/200k) not cache breakdown
-    [[ "$result" == *"84k/200k"* ]]
+    # Should not contain cache indicator
     [[ "$result" != *"C:"* ]]
     [[ "$result" != *"R:"* ]]
 }
 
-@test "cache breakdown with zero creation tokens" {
+# =============================================================================
+# Cache Token Display Mode Tests
+# =============================================================================
+
+@test "cache display with zero creation tokens" {
     TEST_REPO=$(setup_git_repo)
 
     # C: 0, R: 100k (all reads, no creation)
-    result=$(mock_input_with_cache "$TEST_REPO" 0 100000 200000 50000 50000 | "$STATUSLINE" | strip_colors)
+    result=$(mock_input_with_cache "$TEST_REPO" 0 100000 | "$STATUSLINE" | strip_colors)
 
     [[ "$result" == *"C: 0k"* ]]
     [[ "$result" == *"R: 100k"* ]]
 }
 
-@test "cache breakdown with zero read tokens" {
+@test "cache display with zero read tokens" {
     TEST_REPO=$(setup_git_repo)
 
     # C: 50k, R: 0 (all creation, no reads)
-    result=$(mock_input_with_cache "$TEST_REPO" 50000 0 200000 25000 25000 | "$STATUSLINE" | strip_colors)
+    result=$(mock_input_with_cache "$TEST_REPO" 50000 0 | "$STATUSLINE" | strip_colors)
 
     [[ "$result" == *"C: 50k"* ]]
     [[ "$result" == *"R: 0k"* ]]
 }
 
-@test "cache breakdown in icon mode shows brain emoji" {
+@test "cache display in icon mode shows floppy emoji" {
     TEST_REPO=$(setup_git_repo)
 
     export CLAUDEBAR_MODE=icon
     result=$(mock_input_with_cache "$TEST_REPO" 40000 44000 | "$STATUSLINE")
     unset CLAUDEBAR_MODE
 
-    [[ "$result" == *"🧠"* ]]
+    [[ "$result" == *"💾"* ]]
     [[ "$result" == *"C: 40k"* ]]
 }
 
-@test "cache breakdown in label mode shows Context prefix" {
+@test "cache display in label mode shows Cache prefix" {
     TEST_REPO=$(setup_git_repo)
 
     export CLAUDEBAR_MODE=label
     result=$(mock_input_with_cache "$TEST_REPO" 40000 44000 | "$STATUSLINE" | strip_colors)
     unset CLAUDEBAR_MODE
 
-    [[ "$result" == *"Context:"* ]]
+    [[ "$result" == *"Cache:"* ]]
     [[ "$result" == *"C: 40k"* ]]
 }
 
-@test "cache breakdown in none mode shows minimal output" {
+@test "cache display in none mode shows minimal output" {
     TEST_REPO=$(setup_git_repo)
 
     export CLAUDEBAR_MODE=none
     result=$(mock_input_with_cache "$TEST_REPO" 40000 44000 | "$STATUSLINE" | strip_colors)
     unset CLAUDEBAR_MODE
 
-    [[ "$result" != *"🧠"* ]]
+    [[ "$result" != *"💾"* ]]
     [[ "$result" != *"Context:"* ]]
     [[ "$result" == *"C: 40k"* ]]
 }

--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -52,6 +52,8 @@ mock_input_with_billing() {
     local context_size="${3:-200000}"
     local input_tokens="${4:-40000}"
     local output_tokens="${5:-44000}"
+    local cache_creation="${6:-0}"
+    local cache_read="${7:-0}"
 
     cat <<EOF
 {
@@ -61,7 +63,11 @@ mock_input_with_billing() {
     "context_window": {
         "context_window_size": $context_size,
         "total_input_tokens": $input_tokens,
-        "total_output_tokens": $output_tokens
+        "total_output_tokens": $output_tokens,
+        "current_usage": {
+            "cache_creation_input_tokens": $cache_creation,
+            "cache_read_input_tokens": $cache_read
+        }
     },
     "cost": {
         "total_duration_ms": $duration_ms


### PR DESCRIPTION
## Summary

Removes the context window percentage and progress bar display because Claude Code's statusline API only provides cumulative session tokens, not current context window usage.

- Remove percentage display and progress bar
- Change icon from 🧠 to 💾 (Cache instead of Context)
- Show only cache tokens when available: `💾 C: 40k | R: 44k`
- Update tests and documentation

Closes #114

## Why this change?

The `total_input_tokens` and `total_output_tokens` from Claude Code are **cumulative session totals**, not current context. When auto-compact discards old context, these values aren't adjusted, causing impossible readings like `299%` when the actual context might be at 40%.

See: https://github.com/anthropics/claude-code/issues/13783

## Test plan

- [x] All 107 tests pass
- [x] README updated with new format and limitation note
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)